### PR TITLE
Accept version strings with revision tag

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ fi
 SERVER_VERSION=$(docker version -f "{{.Server.Version}}")
 SERVER_VERSION_MAJOR=$(echo "$SERVER_VERSION" | cut -d'.' -f 1)
 SERVER_VERSION_MINOR=$(echo "$SERVER_VERSION" | cut -d'.' -f 2)
-SERVER_VERSION_BUILD=$(echo "$SERVER_VERSION" | cut -d'.' -f 3)
+SERVER_VERSION_BUILD=$(echo "$SERVER_VERSION" | cut -d'.' -f 3 | cut -d'+' -f 1 | cut -d'~' -f 1 | cut -d'-' -f 1)
 
 if [ "${SERVER_VERSION_MAJOR}" -ge 20 ] &&
   [ "${SERVER_VERSION_MINOR}" -ge 0 ] &&
@@ -118,6 +118,7 @@ if [ "$mode" == "testing" ]; then
     read -rp "Please enter a port: (press enter to use 8080) " input
     if [ -z "$input" ]; then
       local_http_port="8080"
+      break
     else
       local_http_port=$input
       break

--- a/stop.sh
+++ b/stop.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ "$(uname -m)" != "x86_64" ]; then
-    echo "Sorry, Lasius currently only supports x86_64 (amd64) architectures."
-    exit 1
-fi
+current_dir="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 if [ -f "lasius.conf" ]; then
     echo "Reading lasius.conf..."
@@ -14,7 +11,9 @@ else
     exit 1
 fi
 
+cd "$mode"
 docker compose --project-name lasius-"$mode" down
+cd "$current_dir"
 
 if [ "$mode" = "testing" ]; then
     echo "Removing docker volumes in testing mode ..."


### PR DESCRIPTION
- e.g. docker 20.10.24+dfsg1 in Debian 12.
- also fixes minor issues in setup.sh (missing break) and stop.sh (cd to $mode dir)